### PR TITLE
fix prometheus client dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
   compile group: 'io.prometheus', name: 'simpleclient', version: '0.0.26'
   compile group: 'io.prometheus', name: 'simpleclient_servlet', version: '0.0.26'
+  compile group: 'io.prometheus', name: 'simpleclient_common', version: '0.0.26'
 }
 
 uploadArchives {


### PR DESCRIPTION
Unless i have:

> 
10:02:16.707 [vert.x-eventloop-thread-6] ERROR i.v.e.w.impl.RoutingContextImplBase - Unexpected exception in route
java.lang.NoClassDefFoundError: io/prometheus/client/exporter/common/TextFormat
	at io.vertx.ext.prometheus.server.MetricsHandler.lambda$handle$0(MetricsHandler.java:25)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:271)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: io.prometheus.client.exporter.common.TextFormat
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 5 common frames omitted
> 