### PR TITLE
Fix shared use of collectors, fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find latest release on Maven Central.
 
 * Gradle:
 ```groovy
-compile group: 'su.nlq', name: 'vertx-prometheus-metrics', version: '3.5.0'
+compile group: 'su.nlq', name: 'vertx-prometheus-metrics', version: '3.5.1'
 ```
 
 Now you can set and enable Vert.x metrics:
@@ -42,6 +42,7 @@ final Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
 | **0.15.x** | 3.5.0      | 0.1.0      |
 Version adjust
 | **3.5.0**  | 3.5.0      | 0.1.0      |
+| **3.5.1**  | 3.5.1      | 0.2.0      |
 
 ## Options
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'su.nlq'
-version '3.5.0'
+version '3.5.1'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -15,17 +15,17 @@ repositories {
 dependencies {
   compile group: 'org.jetbrains', name: 'annotations', version: '15.0'
 
-  compile group: 'io.vertx', name: 'vertx-core', version: '3.5.0'
-  compile group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
+  compile group: 'io.vertx', name: 'vertx-core', version: '3.5.1'
+  compile group: 'io.vertx', name: 'vertx-web', version: '3.5.1'
                                                                                         
-  compile group: 'io.prometheus', name: 'simpleclient', version: '0.1.0'
-  compile group: 'io.prometheus', name: 'simpleclient_servlet', version: '0.1.0'
-  compile group: 'io.prometheus', name: 'simpleclient_common', version: '0.1.0'
+  compile group: 'io.prometheus', name: 'simpleclient', version: '0.2.0'
+  compile group: 'io.prometheus', name: 'simpleclient_servlet', version: '0.2.0'
+  compile group: 'io.prometheus', name: 'simpleclient_common', version: '0.2.0'
 
   compile group: 'su.nlq', name: 'prometheus-protobuf-servlet', version: '0.1.0'
 
   testCompile group: 'junit', name: 'junit', version: '4.12'
-  testCompile group: 'io.vertx', name: 'vertx-unit', version: '3.5.0'
+  testCompile group: 'io.vertx', name: 'vertx-unit', version: '3.5.1'
 }
 
 jacocoTestReport {

--- a/src/main/java/io/vertx/ext/prometheus/metrics/DatagramSocketPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/DatagramSocketPrometheusMetrics.java
@@ -6,6 +6,7 @@ import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.spi.metrics.DatagramSocketMetrics;
 import io.vertx.ext.prometheus.metrics.counters.BytesCounter;
 import io.vertx.ext.prometheus.metrics.counters.ErrorCounter;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,11 +20,11 @@ public final class DatagramSocketPrometheusMetrics extends PrometheusMetrics imp
 
   private volatile @Nullable SocketAddress namedLocalAddress;
 
-  public DatagramSocketPrometheusMetrics(@NotNull CollectorRegistry registry) {
+  public DatagramSocketPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull CounterFactory counters) {
     super(registry);
     final Supplier<String> localAddress = () -> String.valueOf(namedLocalAddress);
-    bytes = new BytesCounter(NAME, localAddress).register(this);
-    errors = new ErrorCounter(NAME, localAddress).register(this);
+    bytes = new BytesCounter(NAME, localAddress, counters);
+    errors = new ErrorCounter(NAME, localAddress, counters);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/prometheus/metrics/HTTPClientPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/HTTPClientPrometheusMetrics.java
@@ -10,6 +10,9 @@ import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.ext.prometheus.metrics.counters.EndpointMetrics;
 import io.vertx.ext.prometheus.metrics.counters.HTTPRequestMetrics;
 import io.vertx.ext.prometheus.metrics.counters.WebsocketGauge;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
+import io.vertx.ext.prometheus.metrics.factories.HistogramFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,11 +23,11 @@ public final class HTTPClientPrometheusMetrics extends TCPPrometheusMetrics impl
   private final @NotNull WebsocketGauge websockets;
   private final @NotNull HTTPRequestMetrics requests;
 
-  public HTTPClientPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String localAddress) {
-    super(registry, NAME, localAddress);
-    requests = new HTTPRequestMetrics(NAME, localAddress).register(this);
-    endpoints = new EndpointMetrics(NAME, localAddress).register(this);
-    websockets = new WebsocketGauge(NAME, localAddress).register(this);
+  public HTTPClientPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String localAddress, @NotNull GaugeFactory gauges, @NotNull CounterFactory counters, @NotNull HistogramFactory histograms) {
+    super(registry, NAME, localAddress, gauges, counters);
+    requests = new HTTPRequestMetrics(NAME, localAddress, gauges, counters, histograms);
+    endpoints = new EndpointMetrics(NAME, localAddress, gauges, histograms);
+    websockets = new WebsocketGauge(NAME, localAddress, gauges);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/prometheus/metrics/HTTPServerPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/HTTPServerPrometheusMetrics.java
@@ -9,6 +9,9 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.ext.prometheus.metrics.counters.HTTPRequestMetrics;
 import io.vertx.ext.prometheus.metrics.counters.WebsocketGauge;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
+import io.vertx.ext.prometheus.metrics.factories.HistogramFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,10 +21,10 @@ public final class HTTPServerPrometheusMetrics extends TCPPrometheusMetrics impl
   private final @NotNull HTTPRequestMetrics requests;
   private final @NotNull WebsocketGauge websockets;
 
-  public HTTPServerPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull SocketAddress localAddress) {
-    super(registry, NAME, localAddress.toString());
-    websockets = new WebsocketGauge(NAME, localAddress.toString()).register(this);
-    requests = new HTTPRequestMetrics(NAME, localAddress.toString()).register(this);
+  public HTTPServerPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull SocketAddress localAddress, @NotNull GaugeFactory gauges, @NotNull CounterFactory counters, @NotNull HistogramFactory histograms) {
+    super(registry, NAME, localAddress.toString(), gauges, counters);
+    websockets = new WebsocketGauge(NAME, localAddress.toString(), gauges);
+    requests = new HTTPRequestMetrics(NAME, localAddress.toString(), gauges, counters, histograms);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/prometheus/metrics/NetClientPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/NetClientPrometheusMetrics.java
@@ -1,11 +1,13 @@
 package io.vertx.ext.prometheus.metrics;
 
 import io.prometheus.client.CollectorRegistry;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class NetClientPrometheusMetrics extends TCPPrometheusMetrics {
 
-  public NetClientPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String localAddress) {
-    super(registry, "netclient", localAddress);
+  public NetClientPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String localAddress, @NotNull GaugeFactory gauges, @NotNull CounterFactory counters) {
+    super(registry, "netclient", localAddress, gauges, counters);
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/NetServerPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/NetServerPrometheusMetrics.java
@@ -2,11 +2,13 @@ package io.vertx.ext.prometheus.metrics;
 
 import io.prometheus.client.CollectorRegistry;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class NetServerPrometheusMetrics extends TCPPrometheusMetrics {
 
-  public NetServerPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull SocketAddress localAddress) {
-    super(registry, "netserver", localAddress.toString());
+  public NetServerPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull SocketAddress localAddress, @NotNull GaugeFactory gauges, @NotNull CounterFactory counters) {
+    super(registry, "netserver", localAddress.toString(), gauges, counters);
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/TCPPrometheusMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/TCPPrometheusMetrics.java
@@ -6,6 +6,8 @@ import io.vertx.core.spi.metrics.TCPMetrics;
 import io.vertx.ext.prometheus.metrics.counters.BytesCounter;
 import io.vertx.ext.prometheus.metrics.counters.ConnectionGauge;
 import io.vertx.ext.prometheus.metrics.counters.ErrorCounter;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,11 +16,11 @@ public abstract class TCPPrometheusMetrics extends PrometheusMetrics implements 
   private final @NotNull BytesCounter bytes;
   private final @NotNull ErrorCounter errors;
 
-  protected TCPPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String name, @NotNull String localAddress) {
+  protected TCPPrometheusMetrics(@NotNull CollectorRegistry registry, @NotNull String name, @NotNull String localAddress, @NotNull GaugeFactory gauges, @NotNull CounterFactory counters) {
     super(registry);
-    connections = new ConnectionGauge(name, localAddress).register(this);
-    errors = new ErrorCounter(name, localAddress).register(this);
-    bytes = new BytesCounter(name, localAddress).register(this);
+    connections = new ConnectionGauge(name, localAddress, gauges);
+    errors = new ErrorCounter(name, localAddress, counters);
+    bytes = new BytesCounter(name, localAddress, counters);
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/BytesCounter.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/BytesCounter.java
@@ -1,7 +1,7 @@
 package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Counter;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
@@ -10,14 +10,13 @@ public final class BytesCounter {
   private final @NotNull Counter counter;
   private final @NotNull Supplier<String> localAddress;
 
-  public BytesCounter(@NotNull String name, @NotNull String localAddress) {
-    this(name, () -> localAddress);
+  public BytesCounter(@NotNull String name, @NotNull String localAddress, @NotNull CounterFactory counters) {
+    this(name, () -> localAddress, counters);
   }
 
-  public BytesCounter(@NotNull String name, @NotNull Supplier<String> localAddress) {
+  public BytesCounter(@NotNull String name, @NotNull Supplier<String> localAddress, @NotNull CounterFactory counters) {
     this.localAddress = localAddress;
-    counter = Counter.build("vertx_" + name + "_bytes", "Read/written bytes")
-        .labelNames("local_address", "type").create();
+    counter = counters.bytes(name);
   }
 
   public void read(long bytes) {
@@ -26,11 +25,6 @@ public final class BytesCounter {
 
   public void written(long bytes) {
     increment("written", bytes);
-  }
-
-  public @NotNull BytesCounter register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(counter);
-    return this;
   }
 
   private void increment(@NotNull String operation, long bytes) {

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/ConnectionGauge.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/ConnectionGauge.java
@@ -1,16 +1,14 @@
 package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Gauge;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class ConnectionGauge {
-  private final @NotNull Gauge gauge;
   private final @NotNull Gauge.Child connections;
 
-  public ConnectionGauge(@NotNull String name, @NotNull String localAddress) {
-    gauge = Gauge.build("vertx_" + name + "_connections", "Active connections number")
-        .labelNames("local_address").create();
+  public ConnectionGauge(@NotNull String name, @NotNull String localAddress, @NotNull GaugeFactory gauges) {
+    Gauge gauge = gauges.connections(name);
     connections = gauge.labels(localAddress);
   }
 
@@ -20,10 +18,5 @@ public final class ConnectionGauge {
 
   public void disconnected() {
     connections.dec();
-  }
-
-  public @NotNull ConnectionGauge register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(gauge);
-    return this;
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/EndpointMetrics.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/EndpointMetrics.java
@@ -2,7 +2,8 @@ package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
+import io.vertx.ext.prometheus.metrics.factories.HistogramFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class EndpointMetrics {
@@ -10,17 +11,10 @@ public final class EndpointMetrics {
   private final @NotNull Stopwatch queueTime;
   private final @NotNull String localAddress;
 
-  public EndpointMetrics(@NotNull String name, @NotNull String localAddress) {
+  public EndpointMetrics(@NotNull String name, @NotNull String localAddress, @NotNull GaugeFactory gauges, @NotNull HistogramFactory histograms) {
     this.localAddress = localAddress;
-    gauge = Gauge.build("vertx_" + name + "_endpoints", "Endpoints number")
-        .labelNames("local_address", "state").create();
-    queueTime = new Stopwatch(name + "_endpoints_queue", localAddress);
-  }
-
-  public @NotNull EndpointMetrics register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(gauge);
-    queueTime.register(metrics);
-    return this;
+    gauge = gauges.endpoints(name);
+    queueTime = new Stopwatch(name + "_endpoints_queue", localAddress, histograms);
   }
 
   public void increment() {

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/ErrorCounter.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/ErrorCounter.java
@@ -1,8 +1,8 @@
 package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Counter;
+import io.vertx.ext.prometheus.metrics.factories.CounterFactory;
 import org.jetbrains.annotations.NotNull;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
 
 import java.util.function.Supplier;
 
@@ -10,22 +10,16 @@ public final class ErrorCounter {
   private final @NotNull Counter counter;
   private final @NotNull Supplier<String> localAddress;
 
-  public ErrorCounter(@NotNull String name, @NotNull String localAddress) {
-    this(name, () -> localAddress);
+  public ErrorCounter(@NotNull String name, @NotNull String localAddress, @NotNull CounterFactory counters) {
+    this(name, () -> localAddress, counters);
   }
 
-  public ErrorCounter(@NotNull String name, @NotNull Supplier<String> localAddress) {
+  public ErrorCounter(@NotNull String name, @NotNull Supplier<String> localAddress, @NotNull CounterFactory counters) {
     this.localAddress = localAddress;
-    counter = Counter.build("vertx_" + name + "_errors", "Errors number")
-        .labelNames("local_address", "class").create();
+    counter = counters.errors(name);
   }
 
   public void increment(@NotNull Throwable throwable) {
     counter.labels(localAddress.get(), throwable.getClass().getSimpleName()).inc();
-  }
-
-  public @NotNull ErrorCounter register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(counter);
-    return this;
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/Stopwatch.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/Stopwatch.java
@@ -1,23 +1,15 @@
 package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Histogram;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
+import io.vertx.ext.prometheus.metrics.factories.HistogramFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class Stopwatch {
-  private final @NotNull Histogram summary;
   private final @NotNull Histogram.Child time;
 
-  public Stopwatch(@NotNull String name, @NotNull String localAddress) {
-    summary = Histogram.build("vertx_" + name + "_time_seconds", "Processing time in seconds")
-        .labelNames("local_address")
-        .create();
+  public Stopwatch(@NotNull String name, @NotNull String localAddress, @NotNull HistogramFactory histograms) {
+    Histogram summary = histograms.timeSeconds(name);
     time = summary.labels(localAddress);
-  }
-
-  public @NotNull Stopwatch register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(summary);
-    return this;
   }
 
   public @NotNull Histogram.Timer start() {

--- a/src/main/java/io/vertx/ext/prometheus/metrics/counters/WebsocketGauge.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/counters/WebsocketGauge.java
@@ -1,16 +1,14 @@
 package io.vertx.ext.prometheus.metrics.counters;
 
 import io.prometheus.client.Gauge;
-import io.vertx.ext.prometheus.metrics.PrometheusMetrics;
+import io.vertx.ext.prometheus.metrics.factories.GaugeFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class WebsocketGauge {
-  private final @NotNull Gauge gauge;
   private final @NotNull Gauge.Child websockets;
 
-  public WebsocketGauge(@NotNull String name, @NotNull String localAddress) {
-    gauge = Gauge.build("vertx_" + name + "_websockets", "Websockets number")
-        .labelNames("local_address").create();
+  public WebsocketGauge(@NotNull String name, @NotNull String localAddress, @NotNull GaugeFactory gauges) {
+    Gauge gauge = gauges.websockets(name);
     websockets = gauge.labels(localAddress);
   }
 
@@ -20,10 +18,5 @@ public final class WebsocketGauge {
 
   public void decrement() {
     websockets.dec();
-  }
-
-  public @NotNull WebsocketGauge register(@NotNull PrometheusMetrics metrics) {
-    metrics.register(gauge);
-    return this;
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/CounterFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/CounterFactory.java
@@ -32,8 +32,8 @@ public class CounterFactory {
    * @return A counter of bytes for the given name. Counters with the same name are shared.
    */
   public Counter bytes(String name) {
-    return counters.computeIfAbsent("vertx_" + name + "_bytes", key -> Counter.build(key, "Read/written bytes")
-        .labelNames("local_address", "type").create());
+    return counters.computeIfAbsent("vertx_" + name + "_bytes", key -> register(Counter.build(key, "Read/written bytes")
+        .labelNames("local_address", "type").create()));
   }
 
   /**
@@ -41,8 +41,8 @@ public class CounterFactory {
    * @return A counter for errors, identified by the given name. Counters with the same name are shared.
    */
   public Counter errors(String name) {
-    return counters.computeIfAbsent("vertx_" + name + "_errors", key -> Counter.build(key, "Errors number")
-        .labelNames("local_address", "class").create());
+    return counters.computeIfAbsent("vertx_" + name + "_errors", key -> register(Counter.build(key, "Errors number")
+        .labelNames("local_address", "class").create()));
   }
 
   /**
@@ -50,7 +50,12 @@ public class CounterFactory {
    * @return A counter of http responses, identified by the given name. Counters with the same name are shared.
    */
   public Counter httpResponses(String name) {
-    return counters.computeIfAbsent("vertx_" + name + "_responses", key -> Counter.build(key, "HTTP responses number")
-        .labelNames("local_address", "code").create());
+    return counters.computeIfAbsent("vertx_" + name + "_responses", key -> register(Counter.build(key, "HTTP responses number")
+        .labelNames("local_address", "code").create()));
+  }
+
+  private Counter register(Counter counter) {
+    registry.register(counter);
+    return counter;
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/CounterFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/CounterFactory.java
@@ -1,0 +1,56 @@
+package io.vertx.ext.prometheus.metrics.factories;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for shared counters.
+ * Counters are identified by name and can only be registered once with a name.
+ *
+ * @author jansorg
+ */
+public class CounterFactory {
+  private final CollectorRegistry registry;
+  private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+  public CounterFactory(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Unregisters the counters which were created by this factory from the registry.
+   */
+  public void close() {
+    counters.values().forEach(registry::unregister);
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A counter of bytes for the given name. Counters with the same name are shared.
+   */
+  public Counter bytes(String name) {
+    return counters.computeIfAbsent("vertx_" + name + "_bytes", key -> Counter.build(key, "Read/written bytes")
+        .labelNames("local_address", "type").create());
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A counter for errors, identified by the given name. Counters with the same name are shared.
+   */
+  public Counter errors(String name) {
+    return counters.computeIfAbsent("vertx_" + name + "_errors", key -> Counter.build(key, "Errors number")
+        .labelNames("local_address", "class").create());
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A counter of http responses, identified by the given name. Counters with the same name are shared.
+   */
+  public Counter httpResponses(String name) {
+    return counters.computeIfAbsent("vertx_" + name + "_responses", key -> Counter.build(key, "HTTP responses number")
+        .labelNames("local_address", "code").create());
+  }
+}

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/GaugeFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/GaugeFactory.java
@@ -32,9 +32,9 @@ public class GaugeFactory {
    * @return A gauge for http requests, identified by the given name. Gauges with the same name are shared.
    */
   public Gauge httpRequests(String name) {
-    return gauges.computeIfAbsent("vertx_" + name + "_requests", key -> Gauge.build(key, "HTTP requests number")
+    return gauges.computeIfAbsent("vertx_" + name + "_requests", key -> register(Gauge.build(key, "HTTP requests number")
         .labelNames("local_address", "method", "path", "state")
-        .create());
+        .create()));
   }
 
   /**
@@ -42,8 +42,8 @@ public class GaugeFactory {
    * @return A gauge for websockets, identified by the given name. Gauges with the same name are shared.
    */
   public Gauge websockets(String name) {
-    return gauges.computeIfAbsent("vertx_" + name + "_websockets", key -> Gauge.build(key, "Websockets number")
-        .labelNames("local_address").create());
+    return gauges.computeIfAbsent("vertx_" + name + "_websockets", key -> register(Gauge.build(key, "Websockets number")
+        .labelNames("local_address").create()));
   }
 
   /**
@@ -51,8 +51,8 @@ public class GaugeFactory {
    * @return A gauge for connections, identified by the given name. Gauges with the same name are shared.
    */
   public Gauge connections(String name) {
-    return gauges.computeIfAbsent("vertx_" + name + "_connections", key -> Gauge.build(key, "Active connections number")
-        .labelNames("local_address").create());
+    return gauges.computeIfAbsent("vertx_" + name + "_connections", key -> register(Gauge.build(key, "Active connections number")
+        .labelNames("local_address").create()));
   }
 
   /**
@@ -60,7 +60,12 @@ public class GaugeFactory {
    * @return A gauge for endpoints, identified by the given name. Gauges with the same name are shared.
    */
   public Gauge endpoints(String name) {
-    return gauges.computeIfAbsent("vertx_" + name + "_endpoints", key -> Gauge.build(key, "Endpoints number")
-        .labelNames("local_address", "state").create());
+    return gauges.computeIfAbsent("vertx_" + name + "_endpoints", key -> register(Gauge.build(key, "Endpoints number")
+        .labelNames("local_address", "state").create()));
+  }
+
+  private Gauge register(Gauge gauge) {
+    registry.register(gauge);
+    return gauge;
   }
 }

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/GaugeFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/GaugeFactory.java
@@ -1,0 +1,66 @@
+package io.vertx.ext.prometheus.metrics.factories;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A factory for shared gauges.
+ * Gauges are identified by name, a gauge can only be shared once in a {@link CollectorRegistry}.
+ *
+ * @author jansorg
+ */
+public class GaugeFactory {
+  private final CollectorRegistry registry;
+  private final Map<String, Gauge> gauges = new ConcurrentHashMap<>();
+
+  public GaugeFactory(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Unregisters the gauges created by this factory from the registry.
+   */
+  public void close() {
+    gauges.values().forEach(registry::unregister);
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A gauge for http requests, identified by the given name. Gauges with the same name are shared.
+   */
+  public Gauge httpRequests(String name) {
+    return gauges.computeIfAbsent("vertx_" + name + "_requests", key -> Gauge.build(key, "HTTP requests number")
+        .labelNames("local_address", "method", "path", "state")
+        .create());
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A gauge for websockets, identified by the given name. Gauges with the same name are shared.
+   */
+  public Gauge websockets(String name) {
+    return gauges.computeIfAbsent("vertx_" + name + "_websockets", key -> Gauge.build(key, "Websockets number")
+        .labelNames("local_address").create());
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A gauge for connections, identified by the given name. Gauges with the same name are shared.
+   */
+  public Gauge connections(String name) {
+    return gauges.computeIfAbsent("vertx_" + name + "_connections", key -> Gauge.build(key, "Active connections number")
+        .labelNames("local_address").create());
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A gauge for endpoints, identified by the given name. Gauges with the same name are shared.
+   */
+  public Gauge endpoints(String name) {
+    return gauges.computeIfAbsent("vertx_" + name + "_endpoints", key -> Gauge.build(key, "Endpoints number")
+        .labelNames("local_address", "state").create());
+  }
+}

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/HistogramFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/HistogramFactory.java
@@ -1,0 +1,38 @@
+package io.vertx.ext.prometheus.metrics.factories;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Histogram;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A factory for shared histograms.
+ *
+ * @author jansorg
+ */
+public class HistogramFactory {
+  private final CollectorRegistry registry;
+  private final Map<String, Histogram> histograms = new ConcurrentHashMap<>();
+
+  public HistogramFactory(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Unregisters the histograms created by this factory from the registry.
+   */
+  public void close() {
+    histograms.values().forEach(registry::unregister);
+  }
+
+  /**
+   * @param name The name of the counter, without prefix and suffix.
+   * @return A histogram for http requests, identified by the given name. Histograms with the same name are shared.
+   */
+  public Histogram timeSeconds(String name) {
+    return histograms.computeIfAbsent("vertx_" + name + "_time_seconds", key -> Histogram.build(key, "Processing time in seconds")
+        .labelNames("local_address")
+        .create());
+  }
+}

--- a/src/main/java/io/vertx/ext/prometheus/metrics/factories/HistogramFactory.java
+++ b/src/main/java/io/vertx/ext/prometheus/metrics/factories/HistogramFactory.java
@@ -31,8 +31,13 @@ public class HistogramFactory {
    * @return A histogram for http requests, identified by the given name. Histograms with the same name are shared.
    */
   public Histogram timeSeconds(String name) {
-    return histograms.computeIfAbsent("vertx_" + name + "_time_seconds", key -> Histogram.build(key, "Processing time in seconds")
+    return histograms.computeIfAbsent("vertx_" + name + "_time_seconds", key -> register(Histogram.build(key, "Processing time in seconds")
         .labelNames("local_address")
-        .create());
+        .create()));
+  }
+
+  private Histogram register(Histogram histogram) {
+    registry.register(histogram);
+    return histogram;
   }
 }

--- a/src/test/java/io/vertx/ext/prometheus/HTTPServerPrometheusMetricsTest.java
+++ b/src/test/java/io/vertx/ext/prometheus/HTTPServerPrometheusMetricsTest.java
@@ -1,0 +1,45 @@
+package io.vertx.ext.prometheus;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author jansorg
+ */
+public class HTTPServerPrometheusMetricsTest extends PrometheusMetricsTestCase {
+  @Test
+  public void testMultipleServers(TestContext context) {
+    await(2, TimeUnit.SECONDS, async -> vertx().createHttpServer(new HttpServerOptions().setPort(10010).setHost("127.0.0.1"))
+        .requestHandler(event -> event.response().end("Response server 1"))
+        .listen(event -> async.countDown()));
+
+    await(2, TimeUnit.SECONDS, async -> vertx().createHttpServer(new HttpServerOptions().setPort(10020).setHost("127.0.0.1"))
+        .requestHandler(event -> event.response().end("Response server 1"))
+        .listen(event -> async.countDown()));
+
+    //request from both servers using different clients
+    HttpClient client1 = vertx().createHttpClient(new HttpClientOptions().setLocalAddress("127.0.0.1"));
+    await(getAsync -> client1.getNow(10010, "127.0.0.1", "/clientRequest1", response -> getAsync.countDown()));
+
+    HttpClient client2 = vertx().createHttpClient(new HttpClientOptions().setLocalAddress("127.0.0.1"));
+    await(getAsync -> client2.getNow(10020, "127.0.0.1", "/clientRequest2", response -> getAsync.countDown()));
+
+    //make sure that metrics of all servers and clients are contained in the data
+    await(response(buffer -> {
+      String body = buffer.toString();
+      //server metrics
+      context.assertTrue(body.contains("vertx_httpserver_responses{local_address=\"127.0.0.1:10010\",code=\"200\",} 1.0"));
+      context.assertTrue(body.contains("vertx_httpserver_responses{local_address=\"127.0.0.1:10020\",code=\"200\",} 1.0\n"));
+
+      //client metrics
+      context.assertTrue(body.contains("vertx_httpclient_requests{local_address=\"127.0.0.1\",method=\"GET\",path=\"/clientRequest1\",state=\"total\",} 1.0\n"));
+      context.assertTrue(body.contains("vertx_httpclient_requests{local_address=\"127.0.0.1\",method=\"GET\",path=\"/clientRequest2\",state=\"total\",} 1.0\n"));
+    }));
+  }
+
+}

--- a/src/test/java/io/vertx/ext/prometheus/PrometheusMetricsTestCase.java
+++ b/src/test/java/io/vertx/ext/prometheus/PrometheusMetricsTestCase.java
@@ -68,10 +68,14 @@ abstract class PrometheusMetricsTestCase {
     }));
   }
 
-  protected final void await(@NotNull Consumer<Async> task) {
+  protected final void await(long timeout, TimeUnit timeoutUnit, @NotNull Consumer<Async> task) {
     final Async latch = context.async();
     task.accept(latch);
-    latch.await(TIMEOUT);
+    latch.await(timeoutUnit.toMillis(timeout));
+  }
+
+  protected final void await(@NotNull Consumer<Async> task) {
+    await(TIMEOUT, TimeUnit.MILLISECONDS, task);
   }
 
   protected final @NotNull Consumer<Async> response(@NotNull Handler<Buffer> handler) {


### PR DESCRIPTION
- This PR fixes usage of shared gauges, counters and histograms.
- The output at '/metrics' looks good on my end. 
- Tests are not passing due to timeouts, but I think that this isn't related to the changed of this PR
- I'd be very happy if this could be merged. If you need corrections, let me know.
- The remaining direct use of the registry, e.g. `io.vertx.ext.prometheus.VertxPrometheusMetrics.TimerPrometheusMetrics`, could be replaced with the factories. But I didn't want to spend too much time before I know if this PR will be accepted.

Previously gauges, counters and histograms shared their name but were
registered more than once. The register calls failed in prometheus' simpleclient
but these errors were silently ignored. The result was that
only the first collector was used for a name.
Metrics like HTTPServerPrometheusMetrics are instantiated multiple times
and thus need to share gauges, counters and histograms to work properly
across different instances of HTTPServers, HTTPClients etc.

This commit adds factories for shared gauges, counters and histograms.
These are created in VertxPrometheusMetrics and passed around to the different child metrics.
The factories are closed in VertxPrometheusMetrics::close(). They can not
be closed earlier as the collectors need to be registered until the last
client (HTTPServerMetrics, ...) is released. The only safe point to to this
is the initial VertxPrometheusMetrics.

Closes #18 